### PR TITLE
[hamilton] - hamilton-referenceVector-update PR

### DIFF
--- a/Group-05/src/DataGrid.cpp
+++ b/Group-05/src/DataGrid.cpp
@@ -139,7 +139,7 @@ std::tuple<const std::size_t, const std::size_t> DataGrid::shape() const {
  * @param column_index_ Column index to retrieve
  * @return Indexed vector column from DataGrid
  */
-cse::ReferenceVector DataGrid::getColumn(const std::size_t column_index_) {
+cse::ReferenceVector<Datum> DataGrid::getColumn(const std::size_t column_index_) {
   assert(!grid_.empty());
   assert(column_index_ < grid_[0].size());
   assert(column_index_ >= 0);
@@ -148,10 +148,10 @@ cse::ReferenceVector DataGrid::getColumn(const std::size_t column_index_) {
     throw std::out_of_range("Column index out of bounds");
   }
 
-  cse::ReferenceVector column;
+  cse::ReferenceVector<Datum> column;
 
   for (auto &row : grid_) {
-    column.push_back(row.at(column_index_));
+    column.PushBack(row.at(column_index_));
   }
   return column;
 }

--- a/Group-05/src/DataGrid.h
+++ b/Group-05/src/DataGrid.h
@@ -97,7 +97,7 @@ public:
   const Datum &getValue(std::size_t row_index_,
                         std::size_t column_index_) const;
   std::tuple<const std::size_t, const std::size_t> shape() const;
-  cse::ReferenceVector getColumn(std::size_t column_index_);
+  cse::ReferenceVector<Datum> getColumn(std::size_t column_index_);
   void insertDefaultRow(
       std::size_t row_index_ = std::numeric_limits<std::size_t>::max(),
       double default_value_ = 0);

--- a/Group-05/src/ReferenceVector.cpp
+++ b/Group-05/src/ReferenceVector.cpp
@@ -1,65 +1,15 @@
 /**
  * @file ReferenceVector.cpp
  *
- * @author Calen Green
+ * @author Calen Green and Max Krawec
  */
 
 #include "ReferenceVector.h"
 
+// TODO - Remove this file
+// Since this class uses a template type, I think it would cause an error if we made methods
+//   in a cpp file. So I moved all the methods into the header file.
 namespace cse {
 
-/**
- * Removes the last element from the vector.
- */
-void ReferenceVector::pop_back() {
-  if (!mData.empty())
-    mData.pop_back();
-}
-
-/**
- * Accesses a Datum at the given index.
- *
- * @param index The position of the element.
- * @return Datum& Reference to the Datum.
- */
-Datum &ReferenceVector::operator[](size_t index) {
-  if (index >= mData.size())
-    throw std::out_of_range("Index out of range");
-  return *mData[index];
-}
-
-/**
- * Returns a reference to the Datum at a position.
- *
- * @param index The index of the desired element.
- * @return Datum& Reference to the Datum.
- */
-Datum &ReferenceVector::at(size_t index) {
-  if (index >= mData.size())
-    throw std::out_of_range("Index out of range");
-  return *mData[index];
-}
-
-/**
- * Returns a reference to the first Datum in the vector.
- *
- * @return Datum& Reference to the first Datum.
- */
-Datum &ReferenceVector::front() {
-  if (mData.empty())
-    throw std::out_of_range("ReferenceVector is empty");
-  return *mData.front();
-}
-
-/**
- * Returns a reference to the last Datum in the vector.
- *
- * @return Datum& Reference to the last Datum.
- */
-Datum &ReferenceVector::back() {
-  if (mData.empty())
-    throw std::out_of_range("ReferenceVector is empty");
-  return *mData.back();
-}
 
 } // namespace cse

--- a/Group-05/src/ReferenceVector.h
+++ b/Group-05/src/ReferenceVector.h
@@ -1,102 +1,156 @@
 /**
  * @file ReferenceVector.h
  *
- * @author Calen Green
+ * @author Calen Green and Max Krawec
  *
- * A vector class that keeps pointers to Datum instances under the hood.
+ * A vector class that keeps pointers to a type of objects,
+ * allowing for entries into the vector to be treated like references.
  */
 
 #pragma once
 
 #include "Datum.h"
+
+#include <cassert>
 #include <memory>
 #include <stdexcept>
 #include <vector>
 
 namespace cse {
 
+template<typename template_type>
 class ReferenceVector {
-private:
-  /// Stores pointers to Datum instances.
-  std::vector<Datum *> mData;
+ private:
+  /// Stores pointers to a type of objects.
+  std::vector<template_type*> references_;
 
-public:
+ public:
   /**
    * Default constructor for ReferenceVector.
    */
   ReferenceVector() = default;
 
   /**
-   * Pushes a Datum reference into the vector.
-   *
-   * @param datum The reference to a Datum.
+   * Pushes an object reference into the vector.
+   * @param value The reference to an object.
    */
-  void push_back(Datum &datum) { mData.push_back(&datum); }
+  void PushBack(template_type &value) { references_.push_back(&value); }
 
   /**
    * Removes the last element in the vector.
    */
-  void pop_back();
+  void PopBack() {
+    assert(!references_.empty());
+    references_.pop_back();
+  };
 
   /**
    * Returns the number of elements in the vector.
-   *
    * @return size_t The size of the vector.
    */
-  size_t size() const { return mData.size(); }
+  [[nodiscard]] size_t Size() const { return references_.size(); }
 
   /**
    * Checks if the vector is empty.
-   *
    * @return bool True if empty, otherwise false.
    */
-  bool empty() const { return mData.empty(); }
+  [[nodiscard]] bool Empty() const { return references_.empty(); }
 
   /**
    * Clears all elements from the vector.
    */
-  void clear() { mData.clear(); }
+  void Clear() { references_.clear(); }
 
   /**
-   * Accesses a Datum reference at the given index.
-   *
-   * @param index The position of the element.
-   * @return Datum& Reference to the Datum at the index.
+ * Returns a reference to the first object in the vector.
+ * @return template_type& Reference to the first template_type.
+ */
+  template_type &Front() {
+    assert(!references_.empty());
+    return *references_.front();
+  };
+
+  /**
+   * Returns a reference to the last template_type in the vector.
+   * @return template_type& Reference to the last template_type.
    */
-  Datum &operator[](size_t index);
+  template_type &Back() {
+    assert(!references_.empty());
+    return *references_.back();
+  };
 
   /**
-   * Returns a reference to the Datum at the given index.
-   *
+   * Erases the element at the index.
    * @param index The index of the desired element.
-   * @return Datum& Reference to the Datum.
    */
-  Datum &at(size_t index);
+  void Erase(size_t index) {
+    assert(index < references_.size());
+    references_.erase(references_.begin() + index);
+  }
 
   /**
-   * Returns a reference to the first Datum in the vector.
-   *
-   * @return Datum& Reference to the first Datum.
+   * Erases multiple elements at the indices.
+   * @param first The first index to remove.
+   * @param last The first index you don't want removed.
    */
-  Datum &front();
+  void Erase(size_t first, size_t last) {
+    assert(first < references_.size());
+    assert(last <= references_.size());
+    assert(first < last); // TODO - Not sure if they can be equal?
+    assert(first != last);
+    references_.erase(references_.begin() + first, references_.begin() + last);
+  }
 
   /**
-   * Returns a reference to the last Datum in the vector.
-   *
-   * @return Datum& Reference to the last Datum.
+   * Inserts a value at the desired index.
+   * @param index The desired index.
+   * @param value The value to add.
    */
-  Datum &back();
+  void Insert(size_t index, template_type &value) {
+    assert(index < references_.size());
+    references_.insert(references_.begin() + index, &value);
+  }
+
+  /**
+  * Accesses an object reference at the given index.
+  * @param index The position of the element.
+  * @return template_type& Reference to the object at the index.
+  */
+  template_type &operator[](size_t index) {
+    assert(index < references_.size());
+    return *references_[index];
+  };
+
+  /**
+   * Returns a reference to the object at the given index.
+   * @param index The index of the desired element.
+   * @return template_type& Reference to the object.
+   */
+  template_type &At(size_t index) {
+    assert(index < references_.size());
+    return *references_[index];
+  };
+
+  /**
+   * Sets the reference at an index.
+   * @param index The index to update.
+   * @param value The value to update with.
+   */
+  void SetReference(size_t index, template_type &value) {
+    assert(index < references_.size());
+    references_[index] = &value;
+  }
 
   class iterator {
-  private:
-    std::vector<Datum *>::iterator it_;
+   private:
+    std::vector<template_type *>::iterator it_;
 
-  public:
-    explicit iterator(std::vector<Datum *>::iterator it) : it_(it) {}
+   public:
+    explicit iterator(std::vector<template_type *>::iterator it) : it_(it) {}
 
-    Datum &operator*() const { return **it_; }
+    template_type &operator*() const { return **it_; }
 
-    Datum *operator->() const { return *it_; }
+    template_type *operator->() const { return *it_; }
 
     iterator &operator++() {
       ++it_;
@@ -115,19 +169,17 @@ public:
 
   /**
    * Returns an iterator to the beginning of the reference vector.
-   *
-   * @return std::vector<Datum*>::iterator An iterator pointing to the first
+   * @return std::vector<template_type*>::iterator An iterator pointing to the first
    * element.
    */
-  iterator begin() { return iterator(mData.begin()); }
+  iterator begin() { return iterator(references_.begin()); }
 
   /**
    * Returns an iterator to the end of the reference vector.
-   *
-   * @return std::vector<Datum*>::iterator An iterator pointing past the last
+   * @return std::vector<template_type*>::iterator An iterator pointing past the last
    * element.
    */
-  iterator end() { return iterator(mData.end()); }
+  iterator end() { return iterator(references_.end()); }
 };
 
 } // namespace cse

--- a/tests/Group-05/DataGridTests.cpp
+++ b/tests/Group-05/DataGridTests.cpp
@@ -99,7 +99,7 @@ TEST_CASE("DataGrid: Get Row", "[access]") {
 TEST_CASE("DataGrid: Get Column", "[access]") {
   DataGrid grid(3, 3);
   auto column = grid.getColumn(1);
-  CHECK(column.size() == 3);
+  CHECK(column.Size() == 3);
 }
 
 /**

--- a/tests/Group-05/ReferenceVectorTests.cpp
+++ b/tests/Group-05/ReferenceVectorTests.cpp
@@ -1,7 +1,7 @@
 /**
  * @file ReferenceVectorTests.cpp
  *
- * @author Calen Green
+ * @author Calen Green and Max Krawec
  *
  * Tests for the ReferenceVector class.
  */
@@ -14,82 +14,178 @@
 
 #include "../../third-party/Catch/single_include/catch2/catch.hpp"
 
-TEST_CASE("push_back() functionality", "[push_back]") {
+TEST_CASE("PushBack() functionality", "[push_back]") {
   cse::Datum d1(123.123);
   cse::Datum d2("test");
   cse::Datum d3(987);
-  cse::ReferenceVector refVec;
+  cse::ReferenceVector<cse::Datum> reference_vector;
 
-  refVec.push_back(d1);
-  refVec.push_back(d2);
-  refVec.push_back(d3);
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+  reference_vector.PushBack(d3);
 
-  CHECK(refVec.size() == 3);
+  CHECK(reference_vector.Size() == 3);
 }
 
-TEST_CASE("pop_back() functionality", "[pop_back]") {
+TEST_CASE("PopBack() functionality", "[pop_back]") {
   cse::Datum d1(123.123);
   cse::Datum d2("test");
   cse::Datum d3(987);
-  cse::ReferenceVector refVec;
+  cse::ReferenceVector<cse::Datum> reference_vector;
 
-  refVec.push_back(d1);
-  refVec.push_back(d2);
-  refVec.push_back(d3);
-  refVec.pop_back();
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+  reference_vector.PushBack(d3);
+  reference_vector.PopBack();
 
-  CHECK(refVec.size() == 2);
+  CHECK(reference_vector.Size() == 2);
+}
+
+TEST_CASE("Size() functionality", "[size]") {
+  cse::Datum d1(123.123);
+  cse::Datum d2("test");
+  cse::Datum d3(987);
+  cse::ReferenceVector<cse::Datum> reference_vector;
+
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+  reference_vector.PushBack(d3);
+
+  CHECK(reference_vector.Size() == 3);
+}
+
+TEST_CASE("Empty() functionality", "[empty]") {
+  cse::ReferenceVector<cse::Datum> reference_vector;
+  CHECK(reference_vector.Empty());
+
+  cse::Datum d1(123.123);
+  reference_vector.PushBack(d1);
+
+  CHECK(!reference_vector.Empty());
+}
+
+TEST_CASE("Clear() functionality", "[clear]") {
+  cse::ReferenceVector<cse::Datum> reference_vector;
+  cse::Datum d1(123.123);
+  reference_vector.PushBack(d1);
+
+  reference_vector.Clear();
+
+  CHECK(reference_vector.Empty());
 }
 
 TEST_CASE("Element access functionality", "[access]") {
   cse::Datum d1(123.123);
+  cse::Datum d2(987);
+  cse::ReferenceVector<cse::Datum> reference_vector;
+
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+
+  CHECK(reference_vector.Front().GetDouble() == 123.123);
+  CHECK(reference_vector.Back().GetDouble() == 987);
+}
+
+TEST_CASE("Erase() functionality", "[erase]") {
+
+  SECTION("Single index erase") {
+    cse::Datum d1(123.123);
+    cse::Datum d2("test");
+    cse::Datum d3(987);
+    cse::ReferenceVector<cse::Datum> reference_vector;
+
+    reference_vector.PushBack(d1);
+    reference_vector.PushBack(d2);
+    reference_vector.PushBack(d3);
+
+    reference_vector.Erase(0);
+    CHECK(reference_vector.Front().GetString() == "test");
+
+    reference_vector.Erase(1);
+    CHECK(reference_vector.Front().GetString() == "test");
+  }
+
+  SECTION("Multiple indices erase") {
+    cse::Datum d1(123.123);
+    cse::Datum d2("test");
+    cse::Datum d3(987);
+    cse::ReferenceVector<cse::Datum> reference_vector;
+
+    reference_vector.PushBack(d1);
+    reference_vector.PushBack(d2);
+    reference_vector.PushBack(d3);
+
+    SECTION("Remove all indices") {
+      reference_vector.Erase(0, 3);
+      CHECK(reference_vector.Empty());
+    }
+
+    SECTION("Remove a few indices") {
+      reference_vector.Erase(0,2);
+      CHECK(reference_vector.Size() == 1);
+    }
+
+  }
+}
+
+TEST_CASE("Insert functionality", "[insert]") {
+  cse::Datum d1(123.123);
   cse::Datum d2("test");
   cse::Datum d3(987);
-  cse::ReferenceVector refVec;
+  cse::ReferenceVector<cse::Datum> reference_vector;
 
-  refVec.push_back(d1);
-  refVec.push_back(d2);
-  refVec.push_back(d3);
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+  reference_vector.PushBack(d3);
 
-  CHECK(refVec.front().GetDouble() == 123.123);
-  CHECK(refVec.at(1).GetString() == "test");
-  CHECK(refVec.back().GetDouble() == 987);
+  cse::Datum d4("apple");
+  reference_vector.Insert(1, d4);
+
+  CHECK(reference_vector.At(1).GetString() == "apple");
+  CHECK(reference_vector.At(2).GetString() == "test");
+  CHECK(reference_vector.Size() == 4);
 }
 
 TEST_CASE("Element modification functionality", "[modify]") {
   cse::Datum d1(123.123);
   cse::Datum d2("test");
   cse::Datum d3(987);
-  cse::Datum newDatum("UpdatedDatum");
-  cse::Datum newDatum2(987.987);
-  cse::ReferenceVector refVec;
+  cse::Datum new_datum("hello");
+  cse::Datum new_datum1("UpdatedDatum");
+  cse::Datum new_datum2(987.987);
 
-  refVec.push_back(d1);
-  refVec.push_back(d2);
-  refVec.push_back(d3);
+  cse::ReferenceVector<cse::Datum> reference_vector;
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+  reference_vector.PushBack(d3);
 
-  refVec[1] = newDatum;
-  refVec[2] = newDatum2;
-  CHECK(refVec.at(1).GetString() == "UpdatedDatum");
-  CHECK(refVec.at(2).GetDouble() == 987.987);
+  reference_vector[0] = new_datum;
+  reference_vector[1] = new_datum1;
+  reference_vector[2] = new_datum2;
+
+  CHECK(reference_vector.At(0).GetString() == "hello");
+  CHECK(reference_vector.At(1).GetString() == "UpdatedDatum");
+  CHECK(reference_vector.At(2).GetDouble() == 987.987);
+
+  CHECK(reference_vector[0].GetString() == "hello");
+  CHECK(reference_vector[1].GetString() == "UpdatedDatum");
+  CHECK(reference_vector[2].GetDouble() == 987.987);
 }
 
-TEST_CASE("clear() functionality", "[clear]") {
+TEST_CASE("SetReference() functionality", "[set_reference]") {
   cse::Datum d1(123.123);
   cse::Datum d2("test");
   cse::Datum d3(987);
-  cse::ReferenceVector refVec;
 
-  refVec.push_back(d1);
-  refVec.push_back(d2);
-  refVec.push_back(d3);
-  refVec.clear();
+  cse::ReferenceVector<cse::Datum> reference_vector;
+  reference_vector.PushBack(d1);
+  reference_vector.PushBack(d2);
+  reference_vector.PushBack(d3);
 
-  CHECK(refVec.size() == 0);
-}
+  cse::Datum d4("happy");
+  reference_vector.SetReference(0, d4);
+  CHECK(reference_vector[0].GetString() == "happy");
 
-TEST_CASE("empty() functionality", "[empty]") {
-  cse::ReferenceVector refVec;
-
-  CHECK(refVec.empty());
+  d4 = "sad";
+  CHECK(reference_vector[0].GetString() == "sad");
 }


### PR DESCRIPTION
Completed:
1) Made ReferenceVector a template type. Since it's a template type, I moved all the methods into the header file. I think we can remove the ReferenceVector.cpp file. 
2) Added 2 erase methods, insert, and SetReference.
3) Added multiple test cases
4 )Since ReferenceVector.cpp is now a template class, had to update some minor code in DataGrid