### PR TITLE
MemoryFactory Initial Class Final Changes

### DIFF
--- a/tests/Group-10-Tests/TestMemoryFactory.cpp
+++ b/tests/Group-10-Tests/TestMemoryFactory.cpp
@@ -34,22 +34,6 @@ TEST_CASE("MemoryFactory Construction", "[constructor]") {
     cse::MemoryFactory<std::string> stringFactory2 =
         cse::MemoryFactory<std::string>(20);
     REQUIRE(stringFactory2.GetSpace() == 20);
-
-    // Expected to error out due to the negative input
-    try {
-      std::cout << "Testing negative allocation:" << std::endl;
-      cse::MemoryFactory<int> intFactory3 = cse::MemoryFactory<int>(-1);
-    } catch (std::invalid_argument& exception) {
-      std::cout << "Invalid Constructor Argument: -1" << std::endl;
-    }
-
-    // No use in initializing a MemoryFactory with no memory allocated
-    try {
-      std::cout << "Testing zero allocation:" << std::endl;
-      cse::MemoryFactory<int> intFactory3 = cse::MemoryFactory<int>(0);
-    } catch (std::invalid_argument& exception) {
-      std::cout << "Invalid Constructor Argument: 0" << std::endl;
-    }
   }
 
   SECTION("Testing Customized Initial Values for Allocation") {

--- a/tests/Group-10-Tests/TestMemoryFactory.cpp
+++ b/tests/Group-10-Tests/TestMemoryFactory.cpp
@@ -9,12 +9,6 @@
 // Class Header
 #include "../../Group-10/Classes/MemoryFactory.h"
 
-/// Test Initial Construction and Deletion
-/// Test Standard Allocation and Deallocation of int
-/// Test Standard Allocation and Deallocation of string
-/// Test Standard Allocation and Deallocation of a custom struct
-/// Test Custom amounts of Allocation with the same objects
-
 TEST_CASE("MemoryFactory Construction", "[constructor]") {
   SECTION("Testing default construction") {
     // Constructor with Default Size


### PR DESCRIPTION
Added functionality to the MemoryFactory Constructor for users to give it an initial value to assign to all objects. I also replaced an exception with an assert and removed the old tests associated with that exception. Finally, I improved upon the comments.