### PR TITLE
AddTextBox UI + coloring/font working

### DIFF
--- a/Group-09/WebLayout/WebLayout.hpp
+++ b/Group-09/WebLayout/WebLayout.hpp
@@ -59,7 +59,7 @@ class WebLayout {
   std::vector<ImageLayout> images;
   std::string id;
 
-  const void renderTextBox(const std::string &layoutID, const std::string &msg,
+  const void renderTextBox(const std::string &layoutID, const FormattedText &msg,
                            const int &width, const int &height, const int &x,
                            const int &y, const std::string &textboxID);
   void const renderImage(const std::string &layoutID, const std::string &url,

--- a/Group-09/WebLayout/WebLayoutManager.cpp
+++ b/Group-09/WebLayout/WebLayoutManager.cpp
@@ -7,7 +7,6 @@
 
 #include <emscripten/bind.h>
 
-
 namespace cse {
 
 /**
@@ -23,22 +22,29 @@ WebLayoutManager::WebLayoutManager() {
 
   // Set up the event listener for the button click
   EM_ASM({
-    // Setup advance button
-    var advanceButton = document.getElementById("advanceButton");
-    if (advanceButton) {
-      advanceButton.addEventListener(
-          "click", function() { Module._call_advance(); });
-    }
-  });
+           // Setup advance button
+           var advanceButton = document.getElementById("advanceButton");
+           if (advanceButton) {
+             advanceButton.addEventListener(
+                 "click", function()
+             { Module._call_advance(); });
+           }
 
-  EM_ASM({
-    // Setup advance button
-    var rewindButton = document.getElementById("reverseButton");
-    if (rewindButton) {
-      rewindButton.addEventListener(
-          "click", function() { Module._call_rewind(); });
-    }
-  });
+           var rewindButton = document.getElementById("reverseButton");
+           if (rewindButton) {
+             rewindButton.addEventListener(
+                 "click", function()
+             { Module._call_rewind(); });
+           }
+
+           var addTextBoxButton = document.getElementById("addTextBoxButton");
+           if (addTextBoxButton) {
+             addTextBoxButton.addEventListener(
+                 "click", function()
+             { Module._call_addTextBox(); });
+           }
+         });
+
 }
 
 extern "C" {
@@ -46,17 +52,23 @@ EMSCRIPTEN_KEEPALIVE void call_advance() {
   if (g_manager) {
     g_manager->advance();
   } else {
-    std::cerr << "Error: g_manager is null!" << std::endl;
+    std::cout << "ERROR: g_manager is null!" << std::endl;
   }
 }
-}
-extern "C" {
 
 EMSCRIPTEN_KEEPALIVE void call_rewind() {
   if (g_manager) {
     g_manager->rewind();
   } else {
-    std::cerr << "Error: g_manager is null!" << std::endl;
+    std::cout << "ERROR: g_manager is null!" << std::endl;
+  }
+}
+
+EMSCRIPTEN_KEEPALIVE void call_addTextBox() {
+  if (g_manager) {
+    g_manager->addTextBox();
+  } else {
+    std::cout << "ERROR: g_manager is null!" << std::endl;
   }
 }
 }
@@ -149,4 +161,20 @@ void WebLayoutManager::initialize() {
     currentLayout->activateLayout();
   }
 }
+
+void WebLayoutManager::addTextBox() {
+  // Create a new text box with predefined properties
+  FormattedText ft;
+  ft.setText("New Box!");
+  TextBoxConfig tbc;
+  tbc.content = ft;
+  tbc.height = 10;
+  tbc.width = 30;
+  auto newTextBox = std::make_shared<TextBox>("", tbc);
+  TextBoxLayout newLayout = {newTextBox, 50, 50};
+
+  layouts.at(currentPos)->addTextBox(newLayout);
+  //layouts.at(currentPos)->loadPage();
+}
+
 }  // namespace cse

--- a/Group-09/WebLayout/WebLayoutManager.hpp
+++ b/Group-09/WebLayout/WebLayoutManager.hpp
@@ -23,10 +23,11 @@ class WebLayoutManager {
   void advance();
   void rewind();
   void initialize();
+  void addTextBox();
   WebLayoutManager();
 
   // 🔹 Getter for export support
-  const std::vector<std::shared_ptr<WebLayout>>& getLayouts() const {
+  const std::vector<std::shared_ptr<WebLayout>> &getLayouts() const {
     return layouts;
   }
 };

--- a/Group-09/WebLayout/index.html
+++ b/Group-09/WebLayout/index.html
@@ -14,6 +14,7 @@
 </div>
 
 <div class="bottom-nav">
+    <button id="addTextBoxButton">Add TextBox<i class="fa-solid fa-angles-left"></i></button>
     <button id="reverseButton">Last Slide<i class="fa-solid fa-angles-left"></i></button>
     <button id="advanceButton">Next Slide<i class="fa-solid fa-angles-right"></i></button>
 </div>

--- a/Group-09/WebLayout/main.cpp
+++ b/Group-09/WebLayout/main.cpp
@@ -11,7 +11,7 @@
 // Compile with:
 // emcc main.cpp ../Image/Image.cpp WebLayout.cpp WebLayoutManager.cpp -o
 // output.js --shell-file index.html -s EXPORTED_FUNCTIONS="['_main',
-// '_call_advance', '_call_rewind']" -s EXPORTED_RUNTIME_METHODS="['ccall',
+// '_call_advance', '_call_rewind', '_call_addTextBox']" -s EXPORTED_RUNTIME_METHODS="['ccall',
 // 'cwrap']"
 using namespace cse;
 
@@ -27,10 +27,13 @@ int main() {
   ImageLayout il(testImage, 10, 10);
   sampleWebLayout->addImage(il);
 
-  // Setup test textbox
+  // Setup test textbox with different configs
 
   FormattedText ft;
-  ft.setText("Yay a Text Box!");
+  ft.setText("Yay a Green Text Box!");
+  ft.setColor("#18453B");
+  ft.setFont("fantasy");
+  ft.setFontSize(24);
   TextBoxConfig tbc;
   tbc.content = ft;
   tbc.height = 10;
@@ -43,6 +46,9 @@ int main() {
   // Setup test textbox2 (exceed barriers test)
   FormattedText ft2;
   ft2.setText("I'm an out of bounds text box D:");
+  ft2.setColor("#FFC0CB");
+  ft2.setFont("monospace");
+  ft2.setFontSize(36);
   TextBoxConfig tbc2;
   tbc2.content = ft2;
   tbc2.height = 15;
@@ -52,7 +58,7 @@ int main() {
   sampleWebLayout->addTextBox(tbl2);
 
   // Load Page
-  sampleWebLayout->loadPage();
+  //sampleWebLayout->loadPage();
 
   std::shared_ptr<WebLayout> sampleWebLayout2 = std::make_shared<WebLayout>();
   // Setup test Image
@@ -74,7 +80,7 @@ int main() {
 
   TextBoxLayout tbl3(testTextBox3, 10, 10);
   sampleWebLayout2->addTextBox(tbl3);
-  sampleWebLayout2->loadPage();
+  //sampleWebLayout2->loadPage();
 
   WebLayoutManager manager;
   manager.addLayout(sampleWebLayout);


### PR DESCRIPTION
There is a addTextBox botton on the slide area now, it will add a defaulted text box to the middle of the screen and stays consistent when switching between slides.

Next is ability to reposition items. Which could be done maybe two ways:

1. dragging all items would auto update them
2. clicking an edit button and then selecting which item to reposition could pull up an input form where you re-enter x,y coordinates so we wouldn't have to deal with the visual drag functions

But thats an issue for another day :D